### PR TITLE
C3_build_script: Adapt for new neutron-clang release approach

### DIFF
--- a/Kernel/C3_build_script.sh
+++ b/Kernel/C3_build_script.sh
@@ -8,6 +8,7 @@ deps() {
 	if [ "${BRANCH}" = "R" ] || [ "${BRANCH}" = "arrow-13.0-llvm" ];then
 	    git clone --depth=1 https://gitlab.com/dakkshesh07/neutron-clang clang
 	    cd clang
+	    bash antman -S
 	    sudo apt install libelf-dev libarchive-tools
 	    bash -c "$(wget -O - https://gist.githubusercontent.com/dakkshesh07/240736992abf0ea6f0ee1d8acb57a400/raw/e97b505653b123b586fc09fda90c4076c8030732/patch-for-old-glibc.sh)"
 	    cd ..


### PR DESCRIPTION
The new approach makes use of AntMan (A Nonsensical Toolchain Manager). AntMan is a toolchain manager written in bash that can be used to download/sync toolchain builds, update them, and manage them.

AntMan-repo: https://github.com/Neutron-Toolchains/antman
Migration-commit: https://github.com/Neutron-Toolchains/clang-build/commit/7dfd33d6c5c941dfd049f41629c0027ddec1ff27