### PR TITLE
scripts: Fix/Add shebangs

### DIFF
--- a/AOSP/aosp-building.sh
+++ b/AOSP/aosp-building.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 echo 'Enter AOSP BRANCH:'
 read AOSPBRANCH
 repo init --depth-1 https://android.googlesource.com/platform/manifest -b $AOSPBRANCH

--- a/Kernel/C3_eva_kernel.sh
+++ b/Kernel/C3_eva_kernel.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function compile() {
 

--- a/Kernel/C3_standalonescript.sh
+++ b/Kernel/C3_standalonescript.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function compile() {
 

--- a/personal/install_jadx.sh
+++ b/personal/install_jadx.sh
@@ -1,4 +1,6 @@
+#!/usr/bin/env bash
 # techyminati <sinha.aryan03@gmail.com>
+
 sudo apt install -y zip
 JADX_VERSION=$(curl -s "https://api.github.com/repos/skylot/jadx/releases/latest" | grep -Po '"tag_name": "v\K[0-9.]+')
 curl -Lo jadx.zip "https://github.com/skylot/jadx/releases/latest/download/jadx-${JADX_VERSION}.zip"


### PR DESCRIPTION
1: Added shebang for the ones which didn't have.
2: Changed shebang for the rest for portability as different *nix distributions install `bash` in different locations, and using `/usr/bin/env` is a workaround for running the `bash` found on the `PATH`.