### PR TITLE
scripts: Simplify antman based clang cloning

### DIFF
--- a/Kernel/C3_build_script.sh
+++ b/Kernel/C3_build_script.sh
@@ -6,9 +6,8 @@ deps() {
 
 	if [ ! -d "clang" ]; then
 		if [ "${BRANCH}" = "R" ] || [ "${BRANCH}" = "arrow-13.0-llvm" ]; then
-			git clone --depth=1 https://gitlab.com/dakkshesh07/neutron-clang clang
-			cd clang
-			bash antman -S
+			mkdir clang && cd clang
+			bash <(curl -s https://raw.githubusercontent.com/Neutron-Toolchains/antman/main/antman) -S=latest
 			sudo apt install libelf-dev libarchive-tools
 			bash -c "$(wget -O - https://gist.githubusercontent.com/dakkshesh07/240736992abf0ea6f0ee1d8acb57a400/raw/e97b505653b123b586fc09fda90c4076c8030732/patch-for-old-glibc.sh)"
 			cd ..


### PR DESCRIPTION
- No need to clone the entire repo where antman resides.

Signed-off-by: Tashfin Shakeer Rhythm <tashfinshakeerrhythm@gmail.com>