### PR TITLE
scripts: Add missing non-quoted backslash

### DIFF
--- a/Kernel/C3_build_script.sh
+++ b/Kernel/C3_build_script.sh
@@ -143,8 +143,8 @@ compile() {
 			NM=llvm-nm \
 			OBJCOPY=llvm-objcopy \
 			OBJDUMP=llvm-objdump \
-			STRIP=llvm-strip
-		CONFIG_NO_ERROR_ON_MISMATCH=y
+			STRIP=llvm-strip \
+			CONFIG_NO_ERROR_ON_MISMATCH=y
 	else
 		make -j"${PROCS}" O=out \
 			ARCH=$ARCH \


### PR DESCRIPTION
CONFIG_NO_ERROR_ON_MISMATCH=y is at a newline. Therefore, to preserve the literal value of it, a non-quoted backslash before the previous flag is necessary.

Signed-off-by: Tashfin Shakeer Rhythm <tashfinshakeerrhythm@gmail.com>