### PR TITLE
scripts: Avoid regenerating defconfig multiple times

### DIFF
--- a/Kernel/C3_build_script.sh
+++ b/Kernel/C3_build_script.sh
@@ -126,11 +126,10 @@ compile() {
 		rm -rf out && mkdir -p out
 	fi
 
-	make O=out ARCH="${ARCH}" "${DEFCONFIG}"
-
 	if [ "${BRANCH}" = "R" ] || [ "${BRANCH}" = "arrow-13.0-llvm" ]; then
 		make -j"${PROCS}" O=out \
-			ARCH=$ARCH \
+			ARCH=${ARCH} \
+			"${DEFCONFIG}" \
 			CC="clang" \
 			CROSS_COMPILE=aarch64-linux-gnu- \
 			CROSS_COMPILE_ARM32=arm-linux-gnueabi- \

--- a/Kernel/C3_eva_kernel.sh
+++ b/Kernel/C3_eva_kernel.sh
@@ -13,10 +13,10 @@ function compile() {
 
 	[ -d "out" ] && rm -rf out || mkdir -p out
 
-	make O=out ARCH=arm64 RMX2020_defconfig
-
 	PATH="${PWD}/gcc/bin:${PATH}:${PWD}/gcc64/bin:/usr/bin:$PATH" \
 		make -j$(nproc --all) O=out \
+		ARCH=arm64 \
+		RMX2020_defconfig \
 		CROSS_COMPILE_ARM32=arm-eabi- \
 		CROSS_COMPILE=aarch64-elf- \
 		LD=aarch64-elf-ld.lld \

--- a/Kernel/C3_standalonescript.sh
+++ b/Kernel/C3_standalonescript.sh
@@ -14,11 +14,10 @@ function compile() {
 
 	[ -d "out" ] && rm -rf out || mkdir -p out
 
-	make O=out ARCH=arm64 RMX2020_defconfig
-
 	PATH="${PWD}/clang/bin:${PATH}:${PWD}/los-4.9-32/bin:${PATH}:${PWD}/los-4.9-64/bin:${PATH}" \
 		make -j$(nproc --all) O=out \
-		ARCH=arm64 \
+		ARCH=${ARCH} \
+		RMX2020_defconfig \
 		CC="clang" \
 		CLANG_TRIPLE=aarch64-linux-gnu- \
 		CROSS_COMPILE="${PWD}/los-4.9-64/bin/aarch64-linux-gnu-" \


### PR DESCRIPTION
defconfig is regenerated when we start cross compiling and it's passed to "make" then. Regenerating beforehand again is just pointless.

Signed-off-by: Tashfin Shakeer Rhythm <tashfinshakeerrhythm@gmail.com>