### PR TITLE
corvus_r5x-script: Use Brightness Curve Patch From ArrowOS

### DIFF
--- a/AOSP Scripts/corvus-r5x.sh
+++ b/AOSP Scripts/corvus-r5x.sh
@@ -14,6 +14,12 @@ cd "${SOURCEDIR}"
 repo init --depth=1 -u https://github.com/Corvus-AOSP/android_manifest.git -b 13
 repo sync  --force-sync --current-branch --no-tags --no-clone-bundle --optimized-fetch --prune -j$(nproc --all)
 
+# Source Patches (Optional)
+cd frameworks/base
+wget https://raw.githubusercontent.com/sarthakroy2002/random-stuff/main/Patches/Fix-brightness-slider-curve-for-some-devices -a12l.patch
+patch -p1 <*.patch
+cd "${SOURCEDIR}"
+
 # Sync Trees
 git clone https://github.com/CorvusRom-Devices/device_realme_r5x -b 13-wip device/realme/r5x
 git clone https://github.com/CorvusRom-Devices/vendor_realme_r5x vendor/realme/r5x


### PR DESCRIPTION
* Without it brigtness scale and control is derped for our device. Credits to @SarthakRoy2022 for the patch

Signed-off-by: Christopher <mizdrake7@gmail.com>