### PR TITLE
build.sh: Patch with latest KernelSU before starting compilation

### DIFF
--- a/Kernel/r5x-Graveyard_build-script.sh
+++ b/Kernel/r5x-Graveyard_build-script.sh
@@ -43,6 +43,11 @@ if ! [ -d "$TC_DIR" ]; then
   fi
 fi
 
+# <---KERNELSU PATCH--->
+
+# Patch with latest KernelSU
+curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -
+
 # <----START COMPILATION--->
 
 if [[ $1 = "-r" || $1 = "--regen" ]]; then


### PR DESCRIPTION
* This will ensure always latest version of KernelSU is shipped without needing to update it as a submodule once in a while.